### PR TITLE
recipeCard title css adjustments #273

### DIFF
--- a/react-frontend/src/recipe-overview/RecipeCard/RecipeCard.js
+++ b/react-frontend/src/recipe-overview/RecipeCard/RecipeCard.js
@@ -13,7 +13,7 @@ export default function RecipeCard(props) {
 				style={{backgroundImage: `url(${getImageUrl(props.images[0])}`}}
 			></div>
 			<div className={styles['recipe-card-infobox']}>
-				<h1 className="titel">{props.title}</h1>
+				<h3 className="titel">{props.title}</h3>
 				<div className={styles['recipe-card-info']}>
 					<span className="material-symbols-outlined">schedule</span>
 					{getFormatedTime(props.time)}

--- a/react-frontend/src/recipe-overview/RecipeCard/RecipeCard.module.css
+++ b/react-frontend/src/recipe-overview/RecipeCard/RecipeCard.module.css
@@ -45,9 +45,12 @@
      margin-bottom: var(--space-2);
 }
 
-.recipe-card h1{
+.recipe-card h3{
     line-height: 1;
-    max-height: calc(2* var(--font-size-heading));
+    max-height: calc(3* var(--font-size-sub-heading));
     margin: 0;
-    margin-bottom: var(--space-3);
+    margin-bottom: var(--space-2);
+    overflow: hidden;
+    text-overflow: ellipsis;
+
 }


### PR DESCRIPTION
Closes #273
visible title lines are 3 instead of 2, the overflow is now hidden